### PR TITLE
fix: add regex to ignore a period in the letter confirmation route

### DIFF
--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -22,9 +22,10 @@ class LettersController < ApplicationController
 
         render js: "window.location='#{new_letter_path(rep_params)}'"
       else
+        binding.pry
         render js: "window.location='#{letters_confirmation_path(params[:body], rep_params)}'"
       end
-      
+
     elsif params[:commit] == 'Preview Letter'
       confirmation = LettersFacade.preview_letter(params[:body], session[:user_id], rep_params)
       @preview_url = confirmation[:data][:attributes][:preview_url]
@@ -34,7 +35,8 @@ class LettersController < ApplicationController
   end
 
   def confirmation
-    confirmation = LettersFacade.preview_letter(params[:format], session[:user_id], rep_preview_params)
+    binding.pry
+    confirmation = LettersFacade.preview_letter(params[:body], session[:user_id], rep_preview_params)
     @preview_url = confirmation[:data][:attributes][:preview_url]
     @delivery_date = DateTime.parse(confirmation[:data][:attributes][:delivery_date]).strftime("%B %e, %Y")
     sleep(3)

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -22,7 +22,6 @@ class LettersController < ApplicationController
 
         render js: "window.location='#{new_letter_path(rep_params)}'"
       else
-        binding.pry
         render js: "window.location='#{letters_confirmation_path(params[:body], rep_params)}'"
       end
 

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -34,7 +34,6 @@ class LettersController < ApplicationController
   end
 
   def confirmation
-    binding.pry
     confirmation = LettersFacade.preview_letter(params[:body], session[:user_id], rep_preview_params)
     @preview_url = confirmation[:data][:attributes][:preview_url]
     @delivery_date = DateTime.parse(confirmation[:data][:attributes][:delivery_date]).strftime("%B %e, %Y")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,9 +15,9 @@ Rails.application.routes.draw do
   patch '/update', to: 'users#update'
 
   get '/fetch_preview', to: 'letters#preview', as: 'fetch_preview'
-  
+
   get '/letters/confirmation', to: "letters#confirmation"
-  get '/letters/confirmation.:body', to: "letters#confirmation"
+  get '/letters/confirmation.:body', to: "letters#confirmation", body: /[^\/]+/
   resources :letters, only: %i[new create]
   post 'checkout/create', to: "checkout#create"
 


### PR DESCRIPTION
### Project Management
Issue name:

Closes #

------------------------------------------------------------------------------
### Feature Status
* [x] Completed
* [ ] In progress

------------------------------------------------------------------------------
### Test coverage

* [ ] 100% Model Testing
* [ ] 100% Feature Testing

If below 100%, what still needs testing:
- x

------------------------------------------------------------------------------
### Change Log

What I did:
- add some regex to a route and rename a param[:format] to param[:body]

Things to consider:
- x

What needs to be refactored:
- x

What still needs help:
- x
